### PR TITLE
Implementing main.go file like project startup

### DIFF
--- a/cmd/worker-cli/main.go
+++ b/cmd/worker-cli/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/LesterCerioli/worker-generator/pkg/generator"
+	"github.com/urfave/cli/v2" // Instead of "github.com/urfave/cli"
+)
+
+func main() {
+	app := &cli.App{
+		Name:  "worker-cli",
+		Usage: "Generate Go worker templates",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "name",
+				Aliases:  []string{"n"}, // Now valid in v2
+				Usage:    "Project name",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "version",
+				Aliases: []string{"v"},
+				Usage:   "Go version (e.g., 1.24)",
+				Value:   "1.24",
+			},
+			&cli.StringFlag{
+				Name:    "output",
+				Aliases: []string{"o"},
+				Usage:   "Output directory",
+				Value:   "./",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			config := generator.WorkerConfig{
+				ProjectName: c.String("name"),
+				GoVersion:   c.String("version"),
+			}
+			return generator.GenerateWorker(config, c.String("output"))
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Implementing main.go file like project startup

## Summary by Sourcery

Create a CLI application for generating Go worker templates with configurable project parameters

New Features:
- Implement worker-cli with CLI flags for project name, Go version, and output directory

Enhancements:
- Use cli.App from urfave/cli/v2 for improved CLI configuration